### PR TITLE
Chore: upgrading the activerecord dependency to use less than version 5.2

### DIFF
--- a/periscope-activerecord.gemspec
+++ b/periscope-activerecord.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name    = "periscope-activerecord"
-  gem.version = "2.1.1"
+  gem.version = "2.1.2"
 
   gem.author   = "Steve Richert"
   gem.email    = "steve.richert@gmail.com"
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.homepage = "https://github.com/laserlemon/periscope"
   gem.license  = "MIT"
 
-  gem.add_dependency "activerecord", ">= 3", "< 5.1"
+  gem.add_dependency "activerecord", ">= 3", "< 5.2"
   gem.add_dependency "periscope", "~> 2.1.0"
 
   gem.files = %w(


### PR DESCRIPTION
# Description

This will help us prepare for any upgrades for any Rails 5.1.x updates